### PR TITLE
fix: metrics region should be parameterized

### DIFF
--- a/api/template.yaml
+++ b/api/template.yaml
@@ -20,7 +20,7 @@ Globals:
     MemorySize: 1024
     Handler: index.handler
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:12
+      - !Sub arn:aws:lambda:"${AWS::Region}":094274105915:layer:AWSLambdaPowertoolsTypeScript:12
       - !Ref DependencyLayer
     Environment:
       Variables:
@@ -335,13 +335,13 @@ Resources:
               Action:
                 - states:DescribeExecution
                 - states:StopExecution
-              Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${OrderWorkflowStateMachine.Name}:*
+              Resource: !Sub arn:${AWS::Partition}:states:"${AWS::Region}":${AWS::AccountId}:execution:${OrderWorkflowStateMachine.Name}:*
             - Effect: Allow
               Action:
                 - events:PutTargets
                 - events:PutRule
                 - events:DescribeRule
-              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+              Resource: !Sub arn:${AWS::Partition}:events:"${AWS::Region}":${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
       Events:
         StartEvent:
           Type: EventBridgeRule
@@ -360,8 +360,8 @@ Resources:
         LambdaInvoke: !Sub arn:${AWS::Partition}:states:::lambda:invoke
         GenerateOrders: !GetAtt GenerateOrdersFunction.Arn
         SendRequest: !GetAtt SendRequestFunction.Arn
-        OrderApiBaseUrl: !Sub https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com/dev
-        AdminApiBaseUrl: !Sub https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/dev
+        OrderApiBaseUrl: !Sub https://${OrderApi}.execute-api."${AWS::Region}".amazonaws.com/dev
+        AdminApiBaseUrl: !Sub https://${AdminApi}.execute-api."${AWS::Region}".amazonaws.com/dev
         DynamoDbDeleteItem: !Sub arn:${AWS::Partition}:states:::dynamodb:deleteItem
         TableName: !Ref OrderTable
       Policies:
@@ -416,19 +416,19 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "label": "get-all-orders-total", "region": ${AWS::Region} } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "label": "get-all-orders-ddb", "region": ${AWS::Region} } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "label": "get-all-orders-cache", "region": ${AWS::Region} } ],
-                                [ ".", "get-my-orders-latency-total", ".", ".", { "label": "get-my-orders-total", "region": ${AWS::Region} } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "label": "get-my-orders-ddb", "region": ${AWS::Region} } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "label": "get-my-orders-cache", "region": ${AWS::Region} } ],
-                                [ ".", "get-order-latency-total", ".", ".", { "region": ${AWS::Region}, "label": "get-order-total" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-order-ddb" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-order-cache" } ]
+                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "label": "get-all-orders-total", "region": "${AWS::Region}" } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "label": "get-all-orders-ddb", "region": "${AWS::Region}" } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "label": "get-all-orders-cache", "region": "${AWS::Region}" } ],
+                                [ ".", "get-my-orders-latency-total", ".", ".", { "label": "get-my-orders-total", "region": "${AWS::Region}" } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "label": "get-my-orders-ddb", "region": "${AWS::Region}" } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "label": "get-my-orders-cache", "region": "${AWS::Region}" } ],
+                                [ ".", "get-order-latency-total", ".", ".", { "region": "${AWS::Region}", "label": "get-order-total" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "${AWS::Region}", "label": "get-order-ddb" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": "${AWS::Region}", "label": "get-order-cache" } ]
                             ],
                             "view": "timeSeries",
                             "stacked": false,
-                            "region": ${AWS::Region},
+                            "region": "${AWS::Region}",
                             "stat": "Average",
                             "period": 60,
                             "title": "Avg Latency"
@@ -442,16 +442,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-all-orders-total Avg" } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-all-orders-ddb Avg" } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-all-orders-cache Avg" } ],
-                                [ ".", "get-all-orders-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-total p99", "color": "#1f77b4" } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-ddb p99", "color": "#ff7f0e" } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-cache p99", "color": "#2ca02c" } ]
+                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "region": "${AWS::Region}", "label": "get-all-orders-total Avg" } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": "${AWS::Region}", "label": "get-all-orders-ddb Avg" } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": "${AWS::Region}", "label": "get-all-orders-cache Avg" } ],
+                                [ ".", "get-all-orders-latency-total", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-all-orders-total p99", "color": "#1f77b4" } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-all-orders-ddb p99", "color": "#ff7f0e" } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-all-orders-cache p99", "color": "#2ca02c" } ]
                                 ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": ${AWS::Region},
+                            "region": "${AWS::Region}",
                             "title": "GetAllOrders Latency",
                             "period": 300,
                             "stat": "Average"
@@ -465,16 +465,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-my-orders-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-my-orders-total Avg", "color": "#d62728" } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-my-orders-ddb Avg", "color": "#9467bd" } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-my-orders-cache Avg", "color": "#8c564b" } ],
-                                [ ".", "get-my-orders-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-total p99" } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-ddb p99" } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-cache p99" } ]
+                                [ "Momento", "get-my-orders-latency-total", "service", "pizza-tracker", { "region": "${AWS::Region}", "label": "get-my-orders-total Avg", "color": "#d62728" } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": "${AWS::Region}", "label": "get-my-orders-ddb Avg", "color": "#9467bd" } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": "${AWS::Region}", "label": "get-my-orders-cache Avg", "color": "#8c564b" } ],
+                                [ ".", "get-my-orders-latency-total", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-my-orders-total p99" } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-my-orders-ddb p99" } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-my-orders-cache p99" } ]
                             ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": ${AWS::Region},
+                            "region": "${AWS::Region}",
                             "title": "GetMyOrders Latency",
                             "period": 300,
                             "stat": "Average"
@@ -488,16 +488,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-order-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-order-total Avg", "color": "#e377c2" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-order-ddb Avg", "color": "#7f7f7f" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-order-cache Avg", "color": "#bcbd22" } ],
-                                [ ".", "get-order-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-total p99", "color": "#e377c2" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-ddb p99", "color": "#7f7f7f" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-cache p99", "color": "#bcbd22" } ]
+                                [ "Momento", "get-order-latency-total", "service", "pizza-tracker", { "region": "${AWS::Region}", "label": "get-order-total Avg", "color": "#e377c2" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "${AWS::Region}", "label": "get-order-ddb Avg", "color": "#7f7f7f" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": "${AWS::Region}", "label": "get-order-cache Avg", "color": "#bcbd22" } ],
+                                [ ".", "get-order-latency-total", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-order-total p99", "color": "#e377c2" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-order-ddb p99", "color": "#7f7f7f" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": "${AWS::Region}", "stat": "p99", "label": "get-order-cache p99", "color": "#bcbd22" } ]
                             ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": ${AWS::Region},
+                            "region": "${AWS::Region}",
                             "title": "GetOrder Latency",
                             "period": 300,
                             "stat": "Average"
@@ -511,19 +511,19 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ { "expression": "m5*100/(m3+m5)", "label": "get-all-orders", "id": "e3", "region": ${AWS::Region} } ],
-                                [ { "expression": "m6*100/(m2+m6)", "label": "get-my-orders", "id": "e2", "region": ${AWS::Region} } ],
-                                [ { "expression": "m4*100/(m1+m4)", "label": "get-order", "id": "e1", "region": ${AWS::Region} } ],
-                                [ "Momento", "get-order-cache-miss", "service", "pizza-tracker", { "region": ${AWS::Region}, "id": "m1", "visible": false } ],
-                                [ ".", "get-my-orders-cache-miss", ".", ".", { "region": ${AWS::Region}, "id": "m2", "visible": false } ],
-                                [ ".", "get-all-orders-cache-miss", ".", ".", { "region": ${AWS::Region}, "id": "m3", "visible": false } ],
-                                [ ".", "get-order-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m4", "visible": false } ],
-                                [ ".", "get-all-orders-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m5", "visible": false } ],
-                                [ ".", "get-my-orders-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m6", "visible": false } ]
+                                [ { "expression": "m5*100/(m3+m5)", "label": "get-all-orders", "id": "e3", "region": "${AWS::Region}" } ],
+                                [ { "expression": "m6*100/(m2+m6)", "label": "get-my-orders", "id": "e2", "region": "${AWS::Region}" } ],
+                                [ { "expression": "m4*100/(m1+m4)", "label": "get-order", "id": "e1", "region": "${AWS::Region}" } ],
+                                [ "Momento", "get-order-cache-miss", "service", "pizza-tracker", { "region": "${AWS::Region}", "id": "m1", "visible": false } ],
+                                [ ".", "get-my-orders-cache-miss", ".", ".", { "region": "${AWS::Region}", "id": "m2", "visible": false } ],
+                                [ ".", "get-all-orders-cache-miss", ".", ".", { "region": "${AWS::Region}", "id": "m3", "visible": false } ],
+                                [ ".", "get-order-cache-hit", ".", ".", { "region": "${AWS::Region}", "id": "m4", "visible": false } ],
+                                [ ".", "get-all-orders-cache-hit", ".", ".", { "region": "${AWS::Region}", "id": "m5", "visible": false } ],
+                                [ ".", "get-my-orders-cache-hit", ".", ".", { "region": "${AWS::Region}", "id": "m6", "visible": false } ]
                             ],
                             "sparkline": true,
                             "view": "gauge",
-                            "region": ${AWS::Region},
+                            "region": "${AWS::Region}",
                             "title": "Cache Hit Rates",
                             "period": 300,
                             "stat": "Sum",
@@ -545,7 +545,7 @@ Resources:
 Outputs:
   OrderApiEndpoint:
     Description: Copy and paste this value in ./order-ui/next.config.js into the NEXT_PUBLIC_ORDER_API property
-    Value: !Sub "https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+    Value: !Sub "https://${OrderApi}.execute-api."${AWS::Region}".amazonaws.com/dev"
   AdminApiEndpoint:
     Description: Copy and paste this value in ./admin-ui/next.config.js into the NEXT_PUBLIC_ADMIN_API property
-    Value: !Sub "https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
+    Value: !Sub "https://${AdminApi}.execute-api."${AWS::Region}".amazonaws.com/dev"

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -416,19 +416,19 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "label": "get-all-orders-total", "region": "us-west-2" } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "label": "get-all-orders-ddb", "region": "us-west-2" } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "label": "get-all-orders-cache", "region": "us-west-2" } ],
-                                [ ".", "get-my-orders-latency-total", ".", ".", { "label": "get-my-orders-total", "region": "us-west-2" } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "label": "get-my-orders-ddb", "region": "us-west-2" } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "label": "get-my-orders-cache", "region": "us-west-2" } ],
-                                [ ".", "get-order-latency-total", ".", ".", { "region": "us-west-2", "label": "get-order-total" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "us-west-2", "label": "get-order-ddb" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": "us-west-2", "label": "get-order-cache" } ]
+                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "label": "get-all-orders-total", "region": ${AWS::Region} } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "label": "get-all-orders-ddb", "region": ${AWS::Region} } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "label": "get-all-orders-cache", "region": ${AWS::Region} } ],
+                                [ ".", "get-my-orders-latency-total", ".", ".", { "label": "get-my-orders-total", "region": ${AWS::Region} } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "label": "get-my-orders-ddb", "region": ${AWS::Region} } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "label": "get-my-orders-cache", "region": ${AWS::Region} } ],
+                                [ ".", "get-order-latency-total", ".", ".", { "region": ${AWS::Region}, "label": "get-order-total" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-order-ddb" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-order-cache" } ]
                             ],
                             "view": "timeSeries",
                             "stacked": false,
-                            "region": "us-west-2",
+                            "region": ${AWS::Region},
                             "stat": "Average",
                             "period": 60,
                             "title": "Avg Latency"
@@ -442,16 +442,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "region": "us-west-2", "label": "get-all-orders-total Avg" } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": "us-west-2", "label": "get-all-orders-ddb Avg" } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": "us-west-2", "label": "get-all-orders-cache Avg" } ],
-                                [ ".", "get-all-orders-latency-total", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-all-orders-total p99", "color": "#1f77b4" } ],
-                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-all-orders-ddb p99", "color": "#ff7f0e" } ],
-                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-all-orders-cache p99", "color": "#2ca02c" } ]
+                                [ "Momento", "get-all-orders-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-all-orders-total Avg" } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-all-orders-ddb Avg" } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-all-orders-cache Avg" } ],
+                                [ ".", "get-all-orders-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-total p99", "color": "#1f77b4" } ],
+                                [ ".", "get-all-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-ddb p99", "color": "#ff7f0e" } ],
+                                [ ".", "get-all-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-all-orders-cache p99", "color": "#2ca02c" } ]
                                 ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": "us-west-2",
+                            "region": ${AWS::Region},
                             "title": "GetAllOrders Latency",
                             "period": 300,
                             "stat": "Average"
@@ -465,16 +465,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-my-orders-latency-total", "service", "pizza-tracker", { "region": "us-west-2", "label": "get-my-orders-total Avg", "color": "#d62728" } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": "us-west-2", "label": "get-my-orders-ddb Avg", "color": "#9467bd" } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": "us-west-2", "label": "get-my-orders-cache Avg", "color": "#8c564b" } ],
-                                [ ".", "get-my-orders-latency-total", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-my-orders-total p99" } ],
-                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-my-orders-ddb p99" } ],
-                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-my-orders-cache p99" } ]
+                                [ "Momento", "get-my-orders-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-my-orders-total Avg", "color": "#d62728" } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-my-orders-ddb Avg", "color": "#9467bd" } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-my-orders-cache Avg", "color": "#8c564b" } ],
+                                [ ".", "get-my-orders-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-total p99" } ],
+                                [ ".", "get-my-orders-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-ddb p99" } ],
+                                [ ".", "get-my-orders-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-my-orders-cache p99" } ]
                             ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": "us-west-2",
+                            "region": ${AWS::Region},
                             "title": "GetMyOrders Latency",
                             "period": 300,
                             "stat": "Average"
@@ -488,16 +488,16 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ "Momento", "get-order-latency-total", "service", "pizza-tracker", { "region": "us-west-2", "label": "get-order-total Avg", "color": "#e377c2" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "us-west-2", "label": "get-order-ddb Avg", "color": "#7f7f7f" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": "us-west-2", "label": "get-order-cache Avg", "color": "#bcbd22" } ],
-                                [ ".", "get-order-latency-total", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-order-total p99", "color": "#e377c2" } ],
-                                [ ".", "get-order-latency-ddb", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-order-ddb p99", "color": "#7f7f7f" } ],
-                                [ ".", "get-order-latency-cache", ".", ".", { "region": "us-west-2", "stat": "p99", "label": "get-order-cache p99", "color": "#bcbd22" } ]
+                                [ "Momento", "get-order-latency-total", "service", "pizza-tracker", { "region": ${AWS::Region}, "label": "get-order-total Avg", "color": "#e377c2" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "label": "get-order-ddb Avg", "color": "#7f7f7f" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "label": "get-order-cache Avg", "color": "#bcbd22" } ],
+                                [ ".", "get-order-latency-total", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-total p99", "color": "#e377c2" } ],
+                                [ ".", "get-order-latency-ddb", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-ddb p99", "color": "#7f7f7f" } ],
+                                [ ".", "get-order-latency-cache", ".", ".", { "region": ${AWS::Region}, "stat": "p99", "label": "get-order-cache p99", "color": "#bcbd22" } ]
                             ],
                             "sparkline": false,
                             "view": "singleValue",
-                            "region": "us-west-2",
+                            "region": ${AWS::Region},
                             "title": "GetOrder Latency",
                             "period": 300,
                             "stat": "Average"
@@ -511,19 +511,19 @@ Resources:
                         "type": "metric",
                         "properties": {
                             "metrics": [
-                                [ { "expression": "m5*100/(m3+m5)", "label": "get-all-orders", "id": "e3", "region": "us-west-2" } ],
-                                [ { "expression": "m6*100/(m2+m6)", "label": "get-my-orders", "id": "e2", "region": "us-west-2" } ],
-                                [ { "expression": "m4*100/(m1+m4)", "label": "get-order", "id": "e1", "region": "us-west-2" } ],
-                                [ "Momento", "get-order-cache-miss", "service", "pizza-tracker", { "region": "us-west-2", "id": "m1", "visible": false } ],
-                                [ ".", "get-my-orders-cache-miss", ".", ".", { "region": "us-west-2", "id": "m2", "visible": false } ],
-                                [ ".", "get-all-orders-cache-miss", ".", ".", { "region": "us-west-2", "id": "m3", "visible": false } ],
-                                [ ".", "get-order-cache-hit", ".", ".", { "region": "us-west-2", "id": "m4", "visible": false } ],
-                                [ ".", "get-all-orders-cache-hit", ".", ".", { "region": "us-west-2", "id": "m5", "visible": false } ],
-                                [ ".", "get-my-orders-cache-hit", ".", ".", { "region": "us-west-2", "id": "m6", "visible": false } ]
+                                [ { "expression": "m5*100/(m3+m5)", "label": "get-all-orders", "id": "e3", "region": ${AWS::Region} } ],
+                                [ { "expression": "m6*100/(m2+m6)", "label": "get-my-orders", "id": "e2", "region": ${AWS::Region} } ],
+                                [ { "expression": "m4*100/(m1+m4)", "label": "get-order", "id": "e1", "region": ${AWS::Region} } ],
+                                [ "Momento", "get-order-cache-miss", "service", "pizza-tracker", { "region": ${AWS::Region}, "id": "m1", "visible": false } ],
+                                [ ".", "get-my-orders-cache-miss", ".", ".", { "region": ${AWS::Region}, "id": "m2", "visible": false } ],
+                                [ ".", "get-all-orders-cache-miss", ".", ".", { "region": ${AWS::Region}, "id": "m3", "visible": false } ],
+                                [ ".", "get-order-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m4", "visible": false } ],
+                                [ ".", "get-all-orders-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m5", "visible": false } ],
+                                [ ".", "get-my-orders-cache-hit", ".", ".", { "region": ${AWS::Region}, "id": "m6", "visible": false } ]
                             ],
                             "sparkline": true,
                             "view": "gauge",
-                            "region": "us-west-2",
+                            "region": ${AWS::Region},
                             "title": "Cache Hit Rates",
                             "period": 300,
                             "stat": "Sum",

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -20,7 +20,7 @@ Globals:
     MemorySize: 1024
     Handler: index.handler
     Layers:
-      - !Sub arn:aws:lambda:"${AWS::Region}":094274105915:layer:AWSLambdaPowertoolsTypeScript:12
+      - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScript:12
       - !Ref DependencyLayer
     Environment:
       Variables:
@@ -335,13 +335,13 @@ Resources:
               Action:
                 - states:DescribeExecution
                 - states:StopExecution
-              Resource: !Sub arn:${AWS::Partition}:states:"${AWS::Region}":${AWS::AccountId}:execution:${OrderWorkflowStateMachine.Name}:*
+              Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${OrderWorkflowStateMachine.Name}:*
             - Effect: Allow
               Action:
                 - events:PutTargets
                 - events:PutRule
                 - events:DescribeRule
-              Resource: !Sub arn:${AWS::Partition}:events:"${AWS::Region}":${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+              Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
       Events:
         StartEvent:
           Type: EventBridgeRule
@@ -360,8 +360,8 @@ Resources:
         LambdaInvoke: !Sub arn:${AWS::Partition}:states:::lambda:invoke
         GenerateOrders: !GetAtt GenerateOrdersFunction.Arn
         SendRequest: !GetAtt SendRequestFunction.Arn
-        OrderApiBaseUrl: !Sub https://${OrderApi}.execute-api."${AWS::Region}".amazonaws.com/dev
-        AdminApiBaseUrl: !Sub https://${AdminApi}.execute-api."${AWS::Region}".amazonaws.com/dev
+        OrderApiBaseUrl: !Sub https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com/dev
+        AdminApiBaseUrl: !Sub https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/dev
         DynamoDbDeleteItem: !Sub arn:${AWS::Partition}:states:::dynamodb:deleteItem
         TableName: !Ref OrderTable
       Policies:

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -545,7 +545,7 @@ Resources:
 Outputs:
   OrderApiEndpoint:
     Description: Copy and paste this value in ./order-ui/next.config.js into the NEXT_PUBLIC_ORDER_API property
-    Value: !Sub "https://${OrderApi}.execute-api."${AWS::Region}".amazonaws.com/dev"
+    Value: !Sub "https://${OrderApi}.execute-api.${AWS::Region}.amazonaws.com/dev"
   AdminApiEndpoint:
     Description: Copy and paste this value in ./admin-ui/next.config.js into the NEXT_PUBLIC_ADMIN_API property
-    Value: !Sub "https://${AdminApi}.execute-api."${AWS::Region}".amazonaws.com/dev"
+    Value: !Sub "https://${AdminApi}.execute-api.${AWS::Region}.amazonaws.com/dev"


### PR DESCRIPTION
Metrics on dashboard were defaulting to us-west-2. Caught this as my region was us-east-1. Tested on my dashboard which can be accessed from our internal console.