### PR TITLE
Add a delay for stream handler to avoid 100% hit rate.

### DIFF
--- a/api/functions/stream-handler/index.js
+++ b/api/functions/stream-handler/index.js
@@ -23,7 +23,7 @@ exports.handler = async (event) => {
 };
 
 const handleNewOrUpdatedCacheItem = async (record) => {
-  await updateOrderRecord(record);
+  setTimeout(updateOrderRecord,20,record);
 };
 
 const updateArrayCacheItem = async (key, item) => {


### PR DESCRIPTION
100% hit rate is not realistic and gives nonsense metrics in CW.